### PR TITLE
update: Use git repo for cloudscraper

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     package_dir={"": SOURCE},
     install_requires=[
         "beautifulsoup4>=4.5.3, <5",
+        "cloudscraper @ git+https://github.com/VeNoMouS/cloudscraper.git@3.0.0",
         "requests>=2.12.4, <3",
     ],
 )


### PR DESCRIPTION
Recent releases are not available on PyPi.